### PR TITLE
Soft Dependency on GTFO API

### DIFF
--- a/MTFO/MTFO.cs
+++ b/MTFO/MTFO.cs
@@ -11,6 +11,7 @@ using UnityEngine.Analytics;
 namespace MTFO
 {
     [BepInPlugin(GUID, MODNAME, VERSION)]
+    [BepInDependency("dev.gtfomodding.gtfo-api", BepInDependency.DependencyFlags.SoftDependency)]
     public class MTFO : BasePlugin
     {
         public const string


### PR DESCRIPTION
BepInExPack_GTFO ships with the GTFO-API since v1.5.0.
A soft dependency on GTFO API allows for MTFO to load right after it so everything is initialized.