### PR TITLE
Implement Json utility

### DIFF
--- a/MTFO/Managers/ConfigManager.cs
+++ b/MTFO/Managers/ConfigManager.cs
@@ -5,7 +5,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using UnityEngine;
-using System.Text.Json;
 
 namespace MTFO.Managers
 {
@@ -51,7 +50,7 @@ namespace MTFO.Managers
             {
                 string content = File.ReadAllText(GameDataLookupPath);
                 Log.Verbose(content);
-                gameDataLookup = JsonSerializer.Deserialize<Dictionary<int, string>>(content, ContentManager.s_SerializerOptions);
+                gameDataLookup = Json.Deserialize<Dictionary<int, string>>(content);
             }
 
             string path = _rundownFolder.Value;

--- a/MTFO/Managers/ContentManager.cs
+++ b/MTFO/Managers/ContentManager.cs
@@ -3,18 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using MTFO.Utilities;
 using MTFO.Custom;
-using System.Text.Json;
 
 namespace MTFO.Managers
 {
     public class ContentManager
     {
-        internal static readonly JsonSerializerOptions s_SerializerOptions = new JsonSerializerOptions
-        {
-            AllowTrailingCommas = true,
-            ReadCommentHandling = JsonCommentHandling.Skip,
-            PropertyNameCaseInsensitive = true
-        };
         private readonly Dictionary<string, Action<string>> Handlers;
         public ScanHolder ScanHolder;
         public GlowstickHolder GlowstickHolder;
@@ -63,19 +56,19 @@ namespace MTFO.Managers
         public void SetupChainedPuzzles(string path)
         {
             Log.Debug("Custom puzzles found");
-            ScanHolder = JsonSerializer.Deserialize<ScanHolder>(File.ReadAllText(path), s_SerializerOptions);
+            ScanHolder = Json.Deserialize<ScanHolder>(File.ReadAllText(path));
         }
 
         public void SetupGlowsticks(string path)
         {
             Log.Debug("Custom glowsticks found");
-            GlowstickHolder = JsonSerializer.Deserialize<GlowstickHolder>(File.ReadAllText(path), s_SerializerOptions);
+            GlowstickHolder = Json.Deserialize<GlowstickHolder>(File.ReadAllText(path));
             GlowstickHolder.Setup();
         }
 
         public void SetupTierNames(string path)
         {
-            TierNames = JsonSerializer.Deserialize<TierNames>(File.ReadAllText(path), s_SerializerOptions);
+            TierNames = Json.Deserialize<TierNames>(File.ReadAllText(path));
         }
     }
 }

--- a/MTFO/Utilities/Json.cs
+++ b/MTFO/Utilities/Json.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+
+namespace MTFO.Utilities
+{
+    public static class Json
+    {
+        /// <summary>
+        /// Checks if a file exists and will deserialize it using the given type, otherwise it will construct the output and write it to a file
+        /// </summary>
+        public static void TryRead<T>(string path, out T output) where T : new()
+        {
+            string json;
+            if (File.Exists(path))
+            {
+                json = File.ReadAllText(path);
+                output = Deserialize<T>(json);
+            }
+            else
+            {
+                output = new();
+                json = Serialize(output);
+                File.WriteAllText(path, json);
+            }
+        }
+
+        public static string Serialize(object value)
+        {
+            return JsonSerializer.Serialize(value, options);
+        }
+
+        public static T Deserialize<T>(string json)
+        {
+            return JsonSerializer.Deserialize<T>(json, options);
+        }
+
+        private static JsonSerializerOptions options = new() {
+            AllowTrailingCommas = true,
+            IncludeFields = true,
+            PropertyNameCaseInsensitive = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            WriteIndented = true
+        };
+    }
+}


### PR DESCRIPTION
Wrote a utility class that wraps the json serializer and gives a unique method that will automatically construct a generic object if the file doesn't exist.
It also privately sets up default settings for the json serializer
This was implemented directly into the `ConfigManager` and `ContentManager`
consider expanding this to wrap or implement a `JsonIgnore` attribute for less namespace usage.