### PR TITLE
Fix for BepInEx v433

### DIFF
--- a/MTFO/Patches/Patch_Analytics.cs
+++ b/MTFO/Patches/Patch_Analytics.cs
@@ -11,7 +11,6 @@ namespace MTFO.Patches
     {
         public static bool Prefix(GameEventData data)
         {
-            Log.Verbose($"{data.customAnalyticsPayload}");
             return false;
         }
     }


### PR DESCRIPTION
Unhollower changes cause the dictionary to cause an access violation when accessing `ToString` due to it being overriden