### PR TITLE
Transition to .NET 6

### DIFF
--- a/MTFO/Dependencies.props
+++ b/MTFO/Dependencies.props
@@ -1,46 +1,40 @@
 <Project InitialTargets="ValidateGamePath">
-  <!--
-    Add a GameFolder.props file to the solution to set your game path:
+    <Import Project="$(MSBuildThisFileDirectory)\GameFolder.props" Condition="Exists('$(MSBuildThisFileDirectory)\GameFolder.props')" />
 
-    <Project>
-      <PropertyGroup>
-        <GameFolder>C:\Program Files (x86)\Steam\steamapps\common\GTFO</GameFolder>
-      </PropertyGroup>
-    </Project>
-  -->
+    <Target Name="ValidateGamePath">
+        <Error Text="The GameFolder property must be set to the GTFO game folder." Condition="'$(GameFolder)' == '' or !Exists('$(GameFolder)')" />
+    </Target>
 
-  <Import Project="$(MSBuildThisFileDirectory)/GameFolder.props" Condition="Exists('$(MSBuildThisFileDirectory)/GameFolder.props')" />
-  <Target Name="ValidateGamePath">
-    <Error Text="The GameFolder property must be set to the GTFO game folder." Condition="'$(GameFolder)' == '' or !Exists('$(GameFolder)')" />
-  </Target>
+    <PropertyGroup>
+        <BIELibsFolder>$(GameFolder)\BepInEx\core</BIELibsFolder>
+        <CorLibsFolder>$(GameFolder)\dotnet\corlib</CorLibsFolder>
+        <InteropLibsFolder>$(GameFolder)\BepInEx\interop</InteropLibsFolder>
+        <PluginsFolder>$(GameFolder)\BepInEx\plugins</PluginsFolder>
+    </PropertyGroup>
 
-  <PropertyGroup>
-    <BIELibsFolder>$(GameFolder)/BepInEx/core</BIELibsFolder>
-    <CorLibsFolder>$(GameFolder)/dotnet/corlib</CorLibsFolder>
-    <UnhollowedLibsFolder>$(GameFolder)/BepInEx/unhollowed</UnhollowedLibsFolder>
-  </PropertyGroup>
+    <!-- NuGet Packages -->
+    <ItemGroup>
+        <PackageReference Include="VersionInfoGenerator" Version="2.0.0" PrivateAssets="all" />
+    </ItemGroup>
 
-  <!-- NuGet dependencies -->
-  <ItemGroup>
-    <PackageReference Include="VersionInfoGenerator" Version="2.0.0" PrivateAssets="all" />
-  </ItemGroup>
+    <!-- Assemblies -->
+    <ItemGroup>
+        <!-- BepInEx -->
+        <Reference Include="$(BIELibsFolder)\BepInEx.*.dll" Private="false" />
+        <Reference Include="$(BIELibsFolder)\0Harmony.dll" Private="false" />
+        <Reference Include="$(BIELibsFolder)\MonoMod.RuntimeDetour.dll" Private="false" />
+        <Reference Include="$(BIELibsFolder)\Il2CppInterop.*.dll" Private="false" />
 
-  <!-- BepInEx libs -->
-  <ItemGroup>
-    <Reference Include="$(BIELibsFolder)/BepInEx.*.dll" Private="false" />
-    <Reference Include="$(BIELibsFolder)/0Harmony.dll" Private="false" />
-    <Reference Include="$(BIELibsFolder)/Il2CppInterop.Runtime.dll" Private="false" />
-  </ItemGroup>
+        <!-- CoreCLR -->
+        <Reference Include="$(CorLibsFolder)\*.dll" Private="false" />
+        <Reference Include="$(CorLibsFolder)\..\System.Private.CoreLib.dll" Private="false" />
 
-  <!-- CoreCLR libs -->
-  <ItemGroup>
-    <Reference Include="$(CorLibsFolder)/*.dll" Private="false" />
-  </ItemGroup>
-
-  <!-- Unhollowed assemblies -->
-  <ItemGroup>
-    <Reference Include="$(UnhollowedLibsFolder)/*.dll" Private="false" />
-    <Reference Remove="$(UnhollowedLibsFolder)/netstandard.dll" />
-    <Reference Remove="$(UnhollowedLibsFolder)/Newtonsoft.Json.dll" />
-  </ItemGroup>
+        <!-- Interop -->
+        <Reference Include="$(InteropLibsFolder)/*.dll" Private="false" />
+        <Reference Remove="$(InteropLibsFolder)/netstandard.dll" />
+        <Reference Remove="$(InteropLibsFolder)/Newtonsoft.Json.dll" />
+	
+        <!-- Plugins -->
+        <Reference Include="$(PluginsFolder)\GTFO-API.dll" Private="false" />
+    </ItemGroup>
 </Project>

--- a/MTFO/Dependencies.props
+++ b/MTFO/Dependencies.props
@@ -16,7 +16,7 @@
 
   <PropertyGroup>
     <BIELibsFolder>$(GameFolder)/BepInEx/core</BIELibsFolder>
-    <MonoLibsFolder>$(GameFolder)/mono/Managed</MonoLibsFolder>
+    <CorLibsFolder>$(GameFolder)/dotnet/corlib</CorLibsFolder>
     <UnhollowedLibsFolder>$(GameFolder)/BepInEx/unhollowed</UnhollowedLibsFolder>
   </PropertyGroup>
 
@@ -29,14 +29,12 @@
   <ItemGroup>
     <Reference Include="$(BIELibsFolder)/BepInEx.*.dll" Private="false" />
     <Reference Include="$(BIELibsFolder)/0Harmony.dll" Private="false" />
-    <Reference Include="$(BIELibsFolder)/UnhollowerBaseLib.dll" Private="false" />
-    <Reference Include="$(BIELibsFolder)/UnhollowerRuntimeLib.dll" Private="false" />
+    <Reference Include="$(BIELibsFolder)/Il2CppInterop.Runtime.dll" Private="false" />
   </ItemGroup>
 
-  <!-- BepInEx mono libs -->
+  <!-- CoreCLR libs -->
   <ItemGroup>
-    <Reference Include="$(MonoLibsFolder)/Microsoft.Bcl.AsyncInterfaces.dll" Private="false" />
-    <Reference Include="$(MonoLibsFolder)/System.Text.Json.dll" Private="false" />
+    <Reference Include="$(CorLibsFolder)/*.dll" Private="false" />
   </ItemGroup>
 
   <!-- Unhollowed assemblies -->

--- a/MTFO/Dependencies.props
+++ b/MTFO/Dependencies.props
@@ -1,40 +1,48 @@
 <Project InitialTargets="ValidateGamePath">
-    <Import Project="$(MSBuildThisFileDirectory)\GameFolder.props" Condition="Exists('$(MSBuildThisFileDirectory)\GameFolder.props')" />
+	<!--
+		Add a GameFolder.props file to the solution to set your game path:
+		<Project>
+			<PropertyGroup>
+				<GameFolder>C:\Program Files (x86)\Steam\steamapps\common\GTFO</GameFolder>
+			</PropertyGroup>
+		</Project>
+	-->
+	<Import Project="$(MSBuildThisFileDirectory)\GameFolder.props" Condition="Exists('$(MSBuildThisFileDirectory)\GameFolder.props')" />
 
-    <Target Name="ValidateGamePath">
-        <Error Text="The GameFolder property must be set to the GTFO game folder." Condition="'$(GameFolder)' == '' or !Exists('$(GameFolder)')" />
-    </Target>
+	<Target Name="ValidateGamePath">
+		<Error Text="The GameFolder property must be set to the GTFO game folder." Condition="'$(GameFolder)' == '' or !Exists('$(GameFolder)')" />
+	</Target>
 
-    <PropertyGroup>
-        <BIELibsFolder>$(GameFolder)\BepInEx\core</BIELibsFolder>
-        <CorLibsFolder>$(GameFolder)\dotnet\corlib</CorLibsFolder>
-        <InteropLibsFolder>$(GameFolder)\BepInEx\interop</InteropLibsFolder>
-        <PluginsFolder>$(GameFolder)\BepInEx\plugins</PluginsFolder>
-    </PropertyGroup>
+	<PropertyGroup>
+		<BIELibsFolder>$(GameFolder)\BepInEx\core</BIELibsFolder>
+		<CorLibsFolder>$(GameFolder)\dotnet\corlib</CorLibsFolder>
+		<InteropLibsFolder>$(GameFolder)\BepInEx\interop</InteropLibsFolder>
+		<PluginsFolder>$(GameFolder)\BepInEx\plugins</PluginsFolder>
+	</PropertyGroup>
 
-    <!-- NuGet Packages -->
-    <ItemGroup>
-        <PackageReference Include="VersionInfoGenerator" Version="2.0.0" PrivateAssets="all" />
-    </ItemGroup>
+	<!-- NuGet Packages -->
+	<ItemGroup>
+		<PackageReference Include="VersionInfoGenerator" Version="2.0.0" PrivateAssets="all" />
+	</ItemGroup>
 
-    <!-- Assemblies -->
-    <ItemGroup>
-        <!-- BepInEx -->
-        <Reference Include="$(BIELibsFolder)\BepInEx.*.dll" Private="false" />
-        <Reference Include="$(BIELibsFolder)\0Harmony.dll" Private="false" />
-        <Reference Include="$(BIELibsFolder)\MonoMod.RuntimeDetour.dll" Private="false" />
-        <Reference Include="$(BIELibsFolder)\Il2CppInterop.*.dll" Private="false" />
+	<!-- Assemblies -->
+	<ItemGroup>
+		<!-- BepInEx -->
+		<Reference Include="$(BIELibsFolder)\BepInEx.*.dll" Private="false" />
+		<Reference Include="$(BIELibsFolder)\0Harmony.dll" Private="false" />
+		<Reference Include="$(BIELibsFolder)\MonoMod.RuntimeDetour.dll" Private="false" />
+		<Reference Include="$(BIELibsFolder)\Il2CppInterop.*.dll" Private="false" />
 
-        <!-- CoreCLR -->
-        <Reference Include="$(CorLibsFolder)\*.dll" Private="false" />
-        <Reference Include="$(CorLibsFolder)\..\System.Private.CoreLib.dll" Private="false" />
+		<!-- CoreCLR -->
+		<Reference Include="$(CorLibsFolder)\*.dll" Private="false" />
+		<Reference Include="$(CorLibsFolder)\..\System.Private.CoreLib.dll" Private="false" />
 
-        <!-- Interop -->
-        <Reference Include="$(InteropLibsFolder)/*.dll" Private="false" />
-        <Reference Remove="$(InteropLibsFolder)/netstandard.dll" />
-        <Reference Remove="$(InteropLibsFolder)/Newtonsoft.Json.dll" />
-	
-        <!-- Plugins -->
-        <Reference Include="$(PluginsFolder)\GTFO-API.dll" Private="false" />
-    </ItemGroup>
+		<!-- Interop -->
+		<Reference Include="$(InteropLibsFolder)/*.dll" Private="false" />
+		<Reference Remove="$(InteropLibsFolder)/netstandard.dll" />
+		<Reference Remove="$(InteropLibsFolder)/Newtonsoft.Json.dll" />
+
+		<!-- Plugins -->
+		<Reference Include="$(PluginsFolder)\GTFO-API.dll" Private="false" />
+	</ItemGroup>
 </Project>

--- a/MTFO/MTFO.cs
+++ b/MTFO/MTFO.cs
@@ -1,12 +1,10 @@
-﻿using CellMenu;
-using MTFO.Managers;
+﻿using MTFO.Managers;
 using MTFO.HotReload;
-using UnhollowerRuntimeLib;
 using BepInEx.IL2CPP;
 using BepInEx;
 using HarmonyLib;
 using UnityEngine.Analytics;
-
+using Il2CppInterop.Runtime.Injection;
 
 namespace MTFO
 {

--- a/MTFO/MTFO.cs
+++ b/MTFO/MTFO.cs
@@ -5,6 +5,7 @@ using BepInEx;
 using HarmonyLib;
 using UnityEngine.Analytics;
 using Il2CppInterop.Runtime.Injection;
+using GTFO.API;
 
 namespace MTFO
 {
@@ -25,11 +26,14 @@ namespace MTFO
 
             var harmony = new Harmony(GUID);
 
-            if (ConfigManager.IsHotReloadEnabled)
+            AssetAPI.OnImplReady += () =>
             {
-                ClassInjector.RegisterTypeInIl2Cpp<HotReloader>();
-                harmony.PatchAll(typeof(HotReloadInjector));
-            }
+                if (ConfigManager.IsHotReloadEnabled)
+                {
+                    ClassInjector.RegisterTypeInIl2Cpp<HotReloader>();
+                    harmony.PatchAll(typeof(HotReloadInjector));
+                }
+            };
                 
             harmony.PatchAll();
         }

--- a/MTFO/MTFO.csproj
+++ b/MTFO/MTFO.csproj
@@ -2,7 +2,7 @@
   <Import Project="Dependencies.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net6</TargetFrameworks>
     <RootNamespace>MTFO</RootNamespace>
     <LangVersion>preview</LangVersion>
     <Copyright>© dakkhuza 2021</Copyright>

--- a/MTFO/Patches/Patch_BinaryDecoder.cs
+++ b/MTFO/Patches/Patch_BinaryDecoder.cs
@@ -2,10 +2,10 @@
 using MTFO.Utilities;
 using HarmonyLib;
 using System.IO;
-using UnhollowerBaseLib;
 using UnityEngine;
 using System.Collections.Generic;
 using GameData;
+using Il2CppInterop.Runtime;
 
 namespace MTFO.Patches
 {

--- a/MTFO/Patches/Patch_BinaryDecoder.cs
+++ b/MTFO/Patches/Patch_BinaryDecoder.cs
@@ -6,6 +6,7 @@ using UnityEngine;
 using System.Collections.Generic;
 using GameData;
 using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.InteropTypes.Arrays;
 
 namespace MTFO.Patches
 {

--- a/MTFO/Patches/Patch_Glowstick.cs
+++ b/MTFO/Patches/Patch_Glowstick.cs
@@ -18,11 +18,11 @@ namespace MTFO.Patches
             if (__instance.m_state == eFadeState.FadeOut || __instance.m_state == eFadeState.Done) return;
             if (!ConfigManager.CustomContent.GlowstickHolder.GlowstickLookup.TryGetValue(__instance.PublicName, out CustomGlowstick customGlowstick)) return;
 
-            if (__instance.m_hasLight)
+            if (__instance.m_light != null)
             {
-                __instance.m_light.SetRange(customGlowstick.Range);
-                __instance.m_light.SetColor(customGlowstick.Color * __instance.m_progression);
-                __instance.m_light.UpdateData();
+                __instance.m_light.Range = customGlowstick.Range;
+                __instance.m_light.Color = customGlowstick.Color * __instance.m_progression;
+                __instance.m_light.UpdateVisibility(true);
             }
         }
     }


### PR DESCRIPTION
## Context
BepInEx's mono domain will be replaced with CoreCLR which will now support .NET 6 and the BepInEx fork of Unhollower will be renamed to Il2CppInterop.

## Summary
Changes the necessary files and dependencies to build and run on the new CoreCLR domain

This PR will be undrafted when a proper build is available