### PR TITLE
Support BepInEx 6.0.0-be.649 Changes

### DIFF
--- a/MTFO/Dependencies.props
+++ b/MTFO/Dependencies.props
@@ -15,7 +15,7 @@
 
 	<PropertyGroup>
 		<BIELibsFolder>$(GameFolder)\BepInEx\core</BIELibsFolder>
-		<CorLibsFolder>$(GameFolder)\dotnet\</CorLibsFolder>
+		<CorLibsFolder>$(GameFolder)\dotnet</CorLibsFolder>
 		<InteropLibsFolder>$(GameFolder)\BepInEx\interop</InteropLibsFolder>
 		<PluginsFolder>$(GameFolder)\BepInEx\plugins</PluginsFolder>
 	</PropertyGroup>

--- a/MTFO/Dependencies.props
+++ b/MTFO/Dependencies.props
@@ -15,7 +15,7 @@
 
 	<PropertyGroup>
 		<BIELibsFolder>$(GameFolder)\BepInEx\core</BIELibsFolder>
-		<CorLibsFolder>$(GameFolder)\dotnet\corlib</CorLibsFolder>
+		<CorLibsFolder>$(GameFolder)\dotnet\</CorLibsFolder>
 		<InteropLibsFolder>$(GameFolder)\BepInEx\interop</InteropLibsFolder>
 		<PluginsFolder>$(GameFolder)\BepInEx\plugins</PluginsFolder>
 	</PropertyGroup>
@@ -35,7 +35,6 @@
 
 		<!-- CoreCLR -->
 		<Reference Include="$(CorLibsFolder)\*.dll" Private="false" />
-		<Reference Include="$(CorLibsFolder)\..\System.Private.CoreLib.dll" Private="false" />
 
 		<!-- Interop -->
 		<Reference Include="$(InteropLibsFolder)/*.dll" Private="false" />

--- a/MTFO/MTFO.cs
+++ b/MTFO/MTFO.cs
@@ -1,6 +1,6 @@
 ﻿using MTFO.Managers;
 using MTFO.HotReload;
-using BepInEx.IL2CPP;
+using BepInEx.Unity.IL2CPP;
 using BepInEx;
 using HarmonyLib;
 using UnityEngine.Analytics;

--- a/MTFO/NativeDetours/Detour_DataBlockBase.cs
+++ b/MTFO/NativeDetours/Detour_DataBlockBase.cs
@@ -1,5 +1,5 @@
 ﻿using BepInEx;
-using BepInEx.IL2CPP.Hook;
+using BepInEx.Unity.IL2CPP.Hook;
 using GameData;
 using GTFO.API;
 using Il2CppInterop.Runtime;


### PR DESCRIPTION
Fixes references corlibs & adjusts namespaces to account for breaking changes post 6.0.0-pre1