### PR TITLE
Add Basic PartialData I/O Support

### DIFF
--- a/MTFO/API/MTFOGameDataAPI.cs
+++ b/MTFO/API/MTFOGameDataAPI.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MTFO.API
+{
+    public delegate void GameDataContentLoadEvent(string datablockName, string jsonContent, in List<string> jsonItemsToInject);
+    public delegate void GameDataContentLoadedDelegate(string datablockName, string jsonContent);
+
+    public static class MTFOGameDataAPI
+    {
+        public static event GameDataContentLoadEvent OnGameDataContentLoad;
+        public static event GameDataContentLoadedDelegate OnGameDataContentLoaded;
+
+        internal static void Invoke_OnGameDataContentLoad(string datablockName, string jsonContent, in List<string> jsonItemsToInject)
+        {
+            OnGameDataContentLoad?.Invoke(datablockName, jsonContent, in jsonItemsToInject);
+        }
+
+        internal static void Invoke_OnGameDataContentLoaded(string datablockName, string jsonContent)
+        {
+            OnGameDataContentLoaded?.Invoke(datablockName, jsonContent);
+        }
+    }
+}

--- a/MTFO/ConfigStrings.Designer.cs
+++ b/MTFO/ConfigStrings.Designer.cs
@@ -19,7 +19,7 @@ namespace MTFO {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class ConfigStrings {
@@ -102,6 +102,24 @@ namespace MTFO {
         internal static string SETTING_DUMPDATA_DESC {
             get {
                 return ResourceManager.GetString("SETTING_DUMPDATA_DESC", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Dump GameData Mode.
+        /// </summary>
+        internal static string SETTING_DUMPDATA_MODE {
+            get {
+                return ResourceManager.GetString("SETTING_DUMPDATA_MODE", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to How to Dump GameData? (Single = Dump gamedata in each single file / PartialData = Dump few gamedata as PartialData / FullPartialData = Dump Everything into PartialData).
+        /// </summary>
+        internal static string SETTING_DUMPDATA_MODE_DESC {
+            get {
+                return ResourceManager.GetString("SETTING_DUMPDATA_MODE_DESC", resourceCulture);
             }
         }
         

--- a/MTFO/ConfigStrings.resx
+++ b/MTFO/ConfigStrings.resx
@@ -136,7 +136,7 @@
     <value>Dump GameData Mode</value>
   </data>
   <data name="SETTING_DUMPDATA_MODE_DESC" xml:space="preserve">
-    <value>How to Dump GameData? (Single = Dump gamedata in each single file / PartialData = Dump few gamedata as PartialData / FullPartialData = Dump Everything into PartialData)</value>
+    <value>The mode in which to dump game data. (Single = Legacy dumping style. Each datablock is writen to it's own file / PartialData = Dumps commonly used datablocks with each entry as it's own file / FullPartialData = Dumps everything as Partial Data)</value>
   </data>
   <data name="SETTING_HOTRELOAD" xml:space="preserve">
     <value>EnableHotReload</value>

--- a/MTFO/ConfigStrings.resx
+++ b/MTFO/ConfigStrings.resx
@@ -132,6 +132,12 @@
   <data name="SETTING_DUMPDATA_DESC" xml:space="preserve">
     <value>Dump GameData to BepInEx/GameData-Dump/revision path?</value>
   </data>
+  <data name="SETTING_DUMPDATA_MODE" xml:space="preserve">
+    <value>Dump GameData Mode</value>
+  </data>
+  <data name="SETTING_DUMPDATA_MODE_DESC" xml:space="preserve">
+    <value>How to Dump GameData? (Single = Dump gamedata in each single file / PartialData = Dump few gamedata as PartialData / FullPartialData = Dump Everything into PartialData)</value>
+  </data>
   <data name="SETTING_HOTRELOAD" xml:space="preserve">
     <value>EnableHotReload</value>
   </data>

--- a/MTFO/Managers/ConfigManager.cs
+++ b/MTFO/Managers/ConfigManager.cs
@@ -10,6 +10,15 @@ using HarmonyLib;
 
 namespace MTFO.Managers
 {
+    using CText = ConfigStrings;
+
+    public enum DumpGameDataMode
+    {
+        Single,
+        PartialData,
+        FullPartialData
+    }
+
     public static class ConfigManager
     {
         private const string CUSTOM_FOLDER = "Custom";
@@ -35,9 +44,10 @@ namespace MTFO.Managers
 
             ConfigFile config = new(CONFIG_PATH, true);
 
-            _enableHotReload = config.Bind(ConfigStrings.SECTION_DEV, ConfigStrings.SETTING_HOTRELOAD, false, ConfigStrings.SETTING_HOTRELOAD_DESC);
-            _dumpGameData = config.Bind(ConfigStrings.SECTION_DEV, ConfigStrings.SETTING_DUMPDATA, false, ConfigStrings.SETTING_DUMPDATA_DESC);
-            _isVerbose = config.Bind(ConfigStrings.SECTION_DEBUG, ConfigStrings.SETTING_VERBOSE, false, ConfigStrings.SETTING_VERBOSE_DESC);
+            _enableHotReload = config.Bind(CText.SECTION_DEV, CText.SETTING_HOTRELOAD, false, CText.SETTING_HOTRELOAD_DESC);
+            _dumpGameData = config.Bind(CText.SECTION_DEV, CText.SETTING_DUMPDATA, false, CText.SETTING_DUMPDATA_DESC);
+            _dumpGameDataMode = config.Bind(CText.SECTION_DEV, CText.SETTING_DUMPDATA_MODE, DumpGameDataMode.Single, CText.SETTING_DUMPDATA_MODE_DESC);
+            _isVerbose = config.Bind(CText.SECTION_DEBUG, CText.SETTING_VERBOSE, false, CText.SETTING_VERBOSE_DESC);
 
             //Get game version
             GAME_VERSION = GetGameVersion();
@@ -100,6 +110,7 @@ namespace MTFO.Managers
         private static readonly ConfigEntry<bool> _enableHotReload;
         private static readonly ConfigEntry<bool> _dumpGameData;
         private static readonly ConfigEntry<bool> _isVerbose;
+        private static readonly ConfigEntry<DumpGameDataMode> _dumpGameDataMode;
 
         public static int GAME_VERSION;
 
@@ -117,27 +128,23 @@ namespace MTFO.Managers
         public static bool IsPluginGameDataPath = false;
         public static bool IsVerbose
         {
-            get
-            {
-                return _isVerbose.Value;
-            }
+            get => _isVerbose.Value;
         }
 
         //Dev Tools
         public static bool IsHotReloadEnabled 
         { 
-            get
-            {
-                return _enableHotReload.Value;
-            } 
+            get => _enableHotReload.Value;
         }
 
         public static bool DumpGameData
         {
-            get
-            {
-                return _dumpGameData.Value;
-            }
+            get => _dumpGameData.Value;
+        }
+
+        public static DumpGameDataMode DumpMode
+        {
+            get => _dumpGameDataMode.Value;
         }
 
         private static int GetGameVersion()

--- a/MTFO/NativeDetours/DataBlockBaseWrapper.cs
+++ b/MTFO/NativeDetours/DataBlockBaseWrapper.cs
@@ -1,0 +1,60 @@
+﻿using GameData;
+using Il2CppInterop.Runtime;
+using Il2CppInterop.Runtime.Runtime;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MTFO.NativeDetours
+{
+    internal class DataBlockBaseWrapper
+    {
+        private static readonly HashSet<string> _PreferPartialDumpBlocks = new()
+        {
+            nameof(RundownDataBlock).ToLower(),
+            nameof(LightSettingsDataBlock).ToLower(),
+            nameof(FogSettingsDataBlock).ToLower(),
+            nameof(LevelLayoutDataBlock).ToLower(),
+            nameof(WardenObjectiveDataBlock).ToLower(),
+            nameof(DimensionDataBlock).ToLower(),
+            nameof(EnemyDataBlock).ToLower(),
+            nameof(EnemySFXDataBlock).ToLower(),
+            nameof(EnemyBehaviorDataBlock).ToLower(),
+            nameof(EnemyBalancingDataBlock).ToLower(),
+            nameof(EnemyMovementDataBlock).ToLower(),
+            nameof(ArchetypeDataBlock).ToLower(),
+            nameof(PlayerOfflineGearDataBlock).ToLower(),
+            nameof(ComplexResourceSetDataBlock).ToLower(),
+            nameof(TextDataBlock).ToLower()
+        };
+
+        public IntPtr ClassPointer { get; private set; }
+        public string FileName { get; private set; }
+        public string BinaryFileName { get; private set; }
+        public bool PreferPartialBlockOnDump { get; private set; } = false; 
+
+        private IntPtr Ptr__m_fileNameNoExt;
+
+        public unsafe DataBlockBaseWrapper(Il2CppMethodInfo* methodInfo)
+        {
+            var method = UnityVersionHandler.Wrap(methodInfo);
+            var klass = UnityVersionHandler.Wrap(method.Class);
+
+            ClassPointer = klass.Pointer;
+            Ptr__m_fileNameNoExt = IL2CPP.GetIl2CppField(klass.Pointer, "m_fileNameNoExt");
+
+            var fileNamePtr = IntPtr.Zero;
+            IL2CPP.il2cpp_field_static_get_value(Ptr__m_fileNameNoExt, &fileNamePtr);
+            FileName = IL2CPP.Il2CppStringToManaged(fileNamePtr).Replace('.', '_');
+            BinaryFileName = FileName + "_bin";
+
+            if (_PreferPartialDumpBlocks.Contains(FileName.ToLower().Replace("gamedata_", "")))
+            {
+                PreferPartialBlockOnDump = true;
+            }
+        }
+    }
+}
+

--- a/MTFO/NativeDetours/Detour_DataBlockBase.cs
+++ b/MTFO/NativeDetours/Detour_DataBlockBase.cs
@@ -56,19 +56,19 @@ namespace MTFO.NativeDetours
                 var datablockName = datablock.BinaryFileName;
                 var jsonFileName = $"{datablockName}.json";
 
-                Log.Verbose($"GetFileContents Call of {datablockName}");
-
-                var json = ReadContent(datablock, originalResult);
-                var jsonNode = json.ToJsonNode();
-                var blocks = jsonNode["Blocks"].AsArray();
-
                 //
                 // Dump Vanilla Blocks
                 //
                 if (ConfigManager.DumpGameData)
                 {
-                    DumpContent(datablock, json);
+                    DumpContent(datablock, IL2CPP.Il2CppStringToManaged(originalResult));
                 }
+
+                Log.Verbose($"GetFileContents Call of {datablockName}");
+
+                var json = ReadContent(datablock, originalResult);
+                var jsonNode = json.ToJsonNode();
+                var blocks = jsonNode["Blocks"].AsArray();
 
                 //
                 // Read Partial Data JSONs
@@ -143,12 +143,6 @@ namespace MTFO.NativeDetours
             var jsonFileName = $"{fileName}.json";
             var originalJson = IL2CPP.Il2CppStringToManaged(originalContentPtr);
 
-            if (ConfigManager.DumpGameData)
-            {
-                File.WriteAllText(Path.Combine(_BasePathToDump, jsonFileName), originalJson);
-                Log.Verbose($"{fileName} has dumped to '{_BasePathToDump}'");
-            }
-
             string filePath = Path.Combine(ConfigManager.GameDataPath, jsonFileName);
             if (File.Exists(filePath))
             {
@@ -177,7 +171,6 @@ namespace MTFO.NativeDetours
                 Log.Verbose($"Unable to dump {datablock.FileName}, Invalid Json Content!");
                 return;
             }
-            var blocks = jsonNode["Blocks"].AsArray();
 
             var shouldMakeItPartialData = false;
             switch (ConfigManager.DumpMode)
@@ -197,6 +190,7 @@ namespace MTFO.NativeDetours
 
             if (shouldMakeItPartialData) //PartialData Dump Moment
             {
+                var blocks = jsonNode["Blocks"].AsArray();
                 var folderName = datablock.FileName;
                 var baseFolder = Path.Combine(_BasePathToDump, folderName);
                 PathUtil.PrepareEmptyDirectory(baseFolder);
@@ -206,6 +200,7 @@ namespace MTFO.NativeDetours
                     var partialJsonFileName = $"{block["persistentID"]}__{block["name"]}.json";
                     var partialDataSavePath = Path.Combine(baseFolder, partialJsonFileName);
                     File.WriteAllText(partialDataSavePath, block.ToJsonStringIndented());
+                    Log.Verbose($" - Save... {partialDataSavePath}");
                 }
                 jsonNode["Blocks"] = new JsonArray();
             }

--- a/MTFO/Utilities/Extensions.cs
+++ b/MTFO/Utilities/Extensions.cs
@@ -2,9 +2,11 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 
-namespace MTFO.Utilities
+namespace MTFO
 {
     public static class DataDumperExtensions
     {

--- a/MTFO/Utilities/JsonNodeExtension.cs
+++ b/MTFO/Utilities/JsonNodeExtension.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
@@ -21,7 +22,8 @@ namespace MTFO
         {
             AllowTrailingCommas = true,
             ReadCommentHandling = JsonCommentHandling.Skip,
-            WriteIndented = true
+            WriteIndented = true,
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         };
 
         public static string ToJsonStringIndented(this JsonNode jsonNode)

--- a/MTFO/Utilities/JsonNodeExtension.cs
+++ b/MTFO/Utilities/JsonNodeExtension.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using System.Threading.Tasks;
+
+namespace MTFO
+{
+    public static class JsonNodeExtension
+    {
+        private static JsonDocumentOptions _JsonDocumentOptions = new()
+        {
+            AllowTrailingCommas = true,
+            CommentHandling = JsonCommentHandling.Skip
+        };
+
+        private static JsonSerializerOptions _JsonSerializerOptions = new()
+        {
+            AllowTrailingCommas = true,
+            ReadCommentHandling = JsonCommentHandling.Skip,
+            WriteIndented = true
+        };
+
+        public static string ToJsonStringIndented(this JsonNode jsonNode)
+        {
+            return jsonNode.ToJsonString(_JsonSerializerOptions);
+        }
+
+        public static bool TryParseToJsonNode(this string json, out JsonNode jsonNode)
+        {
+            try
+            {
+                jsonNode = json.ToJsonNode();
+                return jsonNode != null;
+            }
+            catch
+            {
+                jsonNode = null;
+                return false;
+            }
+        }
+
+        public static bool TryParseJsonNode(this FileStream fileStream, bool dispose, out JsonNode jsonNode)
+        {
+            try
+            {
+                jsonNode = JsonNode.Parse(fileStream, null, _JsonDocumentOptions);
+                return jsonNode != null;
+            }
+            catch
+            {
+                jsonNode = null;
+                return false;
+            }
+            finally
+            {
+                if (dispose)
+                {
+                    fileStream.Close();
+                }
+            }
+        }
+
+        public static JsonNode ToJsonNode(this string json)
+        {
+            return JsonNode.Parse(json, null, _JsonDocumentOptions);
+        }
+
+        public static bool TryAddJsonItem(this JsonArray jsonArray, string json)
+        {
+            try
+            {
+                if (jsonArray == null)
+                {
+                    throw new Exception();
+                }
+
+                if (string.IsNullOrWhiteSpace(json))
+                {
+                    throw new Exception();
+                }
+
+                if (!json.TryParseToJsonNode(out var node))
+                {
+                    throw new Exception();
+                }
+
+                jsonArray.Add(node);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}

--- a/MTFO/Utilities/PathUtil.cs
+++ b/MTFO/Utilities/PathUtil.cs
@@ -44,5 +44,14 @@ namespace MTFO.Utilities
             }
             return dir;
         }
+
+        public static void PrepareEmptyDirectory(string path)
+        {
+            if (Directory.Exists(path))
+            {
+                Directory.Delete(path, true);
+            }
+            Directory.CreateDirectory(path);
+        }
     }
 }


### PR DESCRIPTION
This PR add various system related to PartialData

 - Add `MTFOGameDataAPI` to allow external plugin can inject json in GameData json file
```csharp
MTFOGameDataAPI.OnGameDataContentLoad += (string datablockName, string jsonContent, in List<string> jsonItemsToInject) =>
{
    if (datablockName == "GameData_TextDataBlock")
        jsonItemsToInject.Add("{\"persistentID\": 55, \"name\": \"My New TextDataBlock\"}");
};

MTFOGameDataAPI.OnGameDataContentLoaded += (string datablockName, string jsonContent) =>
{
    if (datablockName == "GameData_TextDataBlock")
        File.WriteAllText(myfilePath, jsonContent);
}
```
 - Add `Dump GameData Mode` `Options: Single, PartialData, FullPartialData` to allow rundown developers to dump GameData in PartialData format like image below:
![image](https://user-images.githubusercontent.com/6457392/230765279-53c92e00-ee46-493d-84eb-98b2955e28f5.png)
 - Add PartialData Parse support to read whatever json file inside each GameData folder
![image](https://user-images.githubusercontent.com/6457392/230765312-be836797-f1f3-48e9-be35-df223f6a0dfd.png)
