### PR TITLE
Create Patch_DiscordManager.cs

### DIFF
--- a/MTFO/Patches/Patch_DiscordManager.cs
+++ b/MTFO/Patches/Patch_DiscordManager.cs
@@ -9,7 +9,7 @@ namespace MTFO.Patches
         [HarmonyPrefix]
         private static bool Pre_UpdateDiscordDetails(eDiscordDetailsDisplay details)
         {
-            if (details == null) return false;
+            if (details == null) return true;
             if (Globals.Global.RundownIdToLoad != 1) return true;
             String detailName = details.ToString();
             if (detailName.Equals("OnSuccess") || detailName.Equals("OnFail"))

--- a/MTFO/Patches/Patch_DiscordManager.cs
+++ b/MTFO/Patches/Patch_DiscordManager.cs
@@ -10,7 +10,7 @@ namespace MTFO.Patches
         private static bool Pre_UpdateDiscordDetails(eDiscordDetailsDisplay details)
         {
             if (details == null) return false;
-
+            if (Globals.Global.RundownIdToLoad != 1) return true;
             String detailName = details.ToString();
             if (detailName.Equals("OnSuccess") || detailName.Equals("OnFail"))
             {

--- a/MTFO/Patches/Patch_DiscordManager.cs
+++ b/MTFO/Patches/Patch_DiscordManager.cs
@@ -1,0 +1,23 @@
+using MTFO.Utilities;
+using HarmonyLib;
+
+namespace MTFO.Patches
+{
+    [HarmonyPatch(typeof(DiscordManager), nameof(DiscordManager.UpdateDiscordDetails))]
+    static class Patch_DiscordManager
+    {
+        [HarmonyPrefix]
+        private static bool Pre_UpdateDiscordDetails(eDiscordDetailsDisplay details)
+        {
+            if (details == null) return false;
+
+            String detailName = details.ToString();
+            if (detailName.Equals("OnSuccess") || detailName.Equals("OnFail"))
+            {
+                Log.Debug($"DiscordManager.UpdateDiscordDetails {detailName} patched out");
+                return false;
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
as discussed with Dex & Kasuromi, a revised version of DiscordManager patch to only prevent OnSuccess and OnFail from bricking end screen (no return to lobby -button).
