### PR TITLE
[Fix] NRE from DiscordManager on expedition success or fail

### DIFF
--- a/MTFO/Patches/Patch_DiscordManager.cs
+++ b/MTFO/Patches/Patch_DiscordManager.cs
@@ -1,0 +1,14 @@
+using HarmonyLib;
+
+namespace MTFO.Patches
+{
+    [HarmonyPatch(typeof(DiscordManager), nameof(DiscordManager.UpdateDiscordDetails))]
+    static class Patch_DiscordManager
+    {
+        [HarmonyPostfix]
+        private static void Post_UpdateDiscordDetails(eDiscordDetailsDisplay details)
+        {
+            // this empty postfix fixes the problem with "return all players to lobby" button.
+        }
+    }
+}


### PR DESCRIPTION
empty postfix on method is enough to fix the missing return to lobby -button.

verified by darkcactus and hirnukuono separately: 
patching in with prefix bool and only a "return true" == problem gone.
patching in with postfix void and doing absolutely nothing == problem gone.

made it real hard to make a configurable patch (which was written and almost PR'ed) when setting false still fixed the problem 100%. hirnu and darkc lost some hair trying to get a "button missing" result after patching, until the conclusion above.
