### PR TITLE
Fix range mod for GlowstickEffect booster

### DIFF
--- a/MTFO/MTFO.csproj
+++ b/MTFO/MTFO.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Copyright>© dakkhuza 2021</Copyright>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <Version>4.6.2</Version>
+    <Version>4.6.3</Version>
     <VersionPrerelease></VersionPrerelease>
 	<AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	<Platforms>x64</Platforms>

--- a/MTFO/Patches/Patch_Glowstick.cs
+++ b/MTFO/Patches/Patch_Glowstick.cs
@@ -20,7 +20,7 @@ namespace MTFO.Patches
 
             if (__instance.m_light != null)
             {
-                __instance.m_light.Range = customGlowstick.Range;
+                __instance.m_light.Range = AgentModifierManager.ApplyModifier(__instance.Owner, AgentModifier.GlowstickEffect, customGlowstick.Range);
                 __instance.m_light.Color = customGlowstick.Color * __instance.m_progression;
                 __instance.m_light.UpdateVisibility(true);
             }


### PR DESCRIPTION
Fixes the range component of the GlowstickEffect booster (Glow Stick Power) not applying to custom glowsticks.